### PR TITLE
Show first annotation

### DIFF
--- a/src/containers/AppBody.jsx
+++ b/src/containers/AppBody.jsx
@@ -4,10 +4,11 @@ import axios from 'axios';
 import { setState } from '../actions/app';
 
 import AnnotationDisplay from './AnnotationDisplay';
-import RulesSelector from '../components/RulesSelector';
 import SnippetArea from './SnippetArea';
-import Error from '../components/Error';
 import Title from './Title';
+import Error from '../components/Error';
+import RulesSelector from '../components/RulesSelector';
+import { getFirstAnnotation } from '../util/annotations';
 
 const API_URL = process.env.API_URL;
 const styles = {
@@ -35,11 +36,14 @@ class AppBody extends Component {
     const { dispatch, snippetKey } = this.props;
     const [user, snippet] = snippetKey.split('/');
     axios.get(`${API_URL}/users/${user}/snippets/${snippet}`)
-      .then((res) => {
+      .then(({ data }) => {
         // Some old snippets don't have a snippetLanguage field, so
         // assume they are 'python3'
-        if (!res.data.snippetLanguage) { res.data.snippetLanguage = 'python3'; }
-        dispatch(setState(res.data));
+        if (!data.snippetLanguage) {
+          data.snippetLanguage = 'python3';
+        }
+        data.selectedLine = getFirstAnnotation(data.annotations);
+        dispatch(setState(data));
       })
       .catch(() => {
         this.setState({error: true})

--- a/src/util/annotations.js
+++ b/src/util/annotations.js
@@ -1,0 +1,7 @@
+import _ from 'lodash';
+
+export const getAnnotatedLines = annotations =>
+  _.sortBy(_.keys(annotations).map(key => Number(key)));
+
+export const getFirstAnnotation = annotations =>
+  _.first(getAnnotatedLines(annotations));


### PR DESCRIPTION
Fixes #32 

This PR refactors AppBody to set `selectedLine` in `componentDidMount` to the first annotation, so that it will be displayed when the snippet loads