### PR TITLE
Improve Layout Within Runestone

### DIFF
--- a/src/components/RulesSelector.jsx
+++ b/src/components/RulesSelector.jsx
@@ -5,7 +5,9 @@ import RuleLabel from './RuleLabel';
 
 const styles = {
   container: {
-    flex: '0 1 auto',
+    display: 'flex',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
   },
 };
 

--- a/src/containers/AnnotationDisplay.jsx
+++ b/src/containers/AnnotationDisplay.jsx
@@ -8,6 +8,7 @@ const styles = {
   container: {
     flex: '1 1 auto',
     maxWidth: '50%',
+    paddingLeft: '25px',
   },
 };
 

--- a/src/containers/AnnotationDisplay.jsx
+++ b/src/containers/AnnotationDisplay.jsx
@@ -7,8 +7,13 @@ import markdownRendererOptions from '../util/markdown-renderer-options';
 const styles = {
   container: {
     flex: '1 1 auto',
-    maxWidth: '50%',
-    paddingLeft: '25px',
+    flexBasis: '50%', // "default width"
+    paddingLeft: '15px',
+  },
+  markdownContainer: {
+    background: '#fff',
+    padding: '10px',
+    borderRadius: '5px',
   },
 };
 
@@ -21,18 +26,20 @@ class AnnotationDisplay extends Component {
     if (selectedLine === -1) {
       return (
         <div style={styles.container}>
-          <h1>Annotation</h1>
+          <h2>Annotation</h2>
         </div>
       );
     }
     const annotation = annotations[selectedLine];
     return (
       <div style={styles.container}>
-        <h1>Annotation</h1>
-        <MarkdownRenderer
-          markdown={annotation.annotation}
-          options={markdownRendererOptions}
-        />
+        <h2>Annotation</h2>
+        <div style={styles.markdownContainer}>
+          <MarkdownRenderer
+            markdown={annotation.annotation}
+            options={markdownRendererOptions}
+          />
+        </div>
       </div>
     );
   }

--- a/src/containers/AppBody.jsx
+++ b/src/containers/AppBody.jsx
@@ -19,6 +19,12 @@ const styles = {
     display: 'flex',
     justifyContent: 'center',
   },
+  wrapper: {
+    margin: '15px',
+    padding: '10px',
+    background: '#f5f6f5',
+    borderRadius: '5px',
+  },
   container: {
     display: 'flex',
     flexFlow: 'row wrap',
@@ -50,7 +56,7 @@ class AppBody extends Component {
     const { error } = this.state;
     if (!error) {
       return (
-        <div>
+        <div style={styles.wrapper}>
           <div style={styles.title}>
             <Title />
           </div>

--- a/src/containers/SnippetArea.jsx
+++ b/src/containers/SnippetArea.jsx
@@ -8,6 +8,7 @@ import Editor from '../components/Editor';
 const styles = {
   container: {
     flex: '1 1 auto',
+    flexBasis: '50%', // "default width"
     marginTop: '30px',
   },
 };


### PR DESCRIPTION
Fixes https://github.com/maryvilledev/codesplain/issues/74.

This PR includes various CSS tweaks that improve the app's layout at various widths.
Note that the app's containing `div` has had its width increased as a result of https://github.com/maryvilledev/RunestoneComponents/commit/0d78f8cd67a03d8bd62bcdf989a2d1766a184169, which contributes to the improved appearance in the screenshots below.

# Screenshots
## Full Width
<img width="1174" alt="screen shot 2017-05-01 at 8 12 04 pm" src="https://cloud.githubusercontent.com/assets/10351828/25600563/9345bd34-2eaa-11e7-9e94-fc1ae682a965.png">
<img width="1171" alt="screen shot 2017-05-01 at 8 12 15 pm" src="https://cloud.githubusercontent.com/assets/10351828/25600565/93488be0-2eaa-11e7-80ee-75604b8740e9.png">

## Smaller Width
<img width="725" alt="screen shot 2017-05-01 at 8 12 38 pm" src="https://cloud.githubusercontent.com/assets/10351828/25600564/9348049a-2eaa-11e7-894c-6ee53272528b.png">
