### PR TITLE
Add ability to navigate between next/previous annotations

### DIFF
--- a/__tests__/util/annotation.test.js
+++ b/__tests__/util/annotation.test.js
@@ -1,0 +1,52 @@
+import * as utils from '../../src/util/annotations';
+
+const annotations = {
+  1: 'Rick Sanchez',
+  2: 'Morty Smith',
+  3: 'Beth Smith',
+  4: 'Summer Smith',
+  // No Jerry
+};
+
+describe('util: annotations:', () => {
+  describe('getFirstAnnotation', () => {
+    it('returns the first annotated line in the array', () => {
+      expect(utils.getFirstAnnotation(annotations)).toEqual(1);
+    });
+    it('returns undefined if there are no annotations', () => {
+      expect(utils.getFirstAnnotation([])).not.toBeDefined();
+    });
+  });
+  describe('getAnnotatedLines', () => {
+    it('should return a sorted array of the keys', () => {
+      const expected = [1, 2, 3, 4];
+      expect(utils.getAnnotatedLines(annotations)).toEqual(expected);
+    });
+  });
+  describe('getNextAnnotation', () => {
+    it('returns the annotation after the currently displayed one', () => {
+      const lineNumber = 1;
+      const expected = annotations[lineNumber + 1];
+      const nextAnnotation = utils.getNextAnnotation(annotations, lineNumber);
+      expect(nextAnnotation).toEqual(expected);
+    });
+    it('returns undefined if there are no annotations after the currently displayed one', () => {
+      const lineNumber = 4;
+      const nextAnnotation = utils.getNextAnnotation(annotations, lineNumber);
+      expect(nextAnnotation).not.toBeDefined();
+    });
+  });
+  describe('getPreviousAnnotation', () => {
+    it('returns the annotation before the currently displayed one', () => {
+      const lineNumber = 3;
+      const expected = annotations[lineNumber - 1];
+      const prevAnnotation = utils.getPreviousAnnotation(annotations, lineNumber);
+      expect(prevAnnotation).toEqual(expected);
+    });
+    it('returns undefined if there are no annotations before the currently displayed one', () => {
+      const lineNumber = 1;
+      const prevAnnotation = utils.getPreviousAnnotation(annotations, lineNumber);
+      expect(prevAnnotation).not.toBeDefined();
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -11,23 +11,25 @@
   },
   "dependencies": {
     "axios": "^0.16.1",
-    "babel-polyfill": "^6.23.0",
-    "babel-preset-stage-2": "^6.24.1",
-    "css-loader": "^0.28.0",
-    "highlight.js": "^9.11.0",
-    "jest": "^19.0.2",
-    "lodash": "^4.17.4",
-    "react-codemirror": "^0.3.0",
-    "react-markdown-renderer": "^1.2.0",
-    "react-redux": "^5.0.4",
-    "redux": "^3.6.0"
-  },
-  "devDependencies": {
     "babel-core": "^6.24.1",
     "babel-eslint": "^7.2.3",
     "babel-loader": "^6.4.1",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
+    "babel-polyfill": "^6.23.0",
+    "babel-preset-stage-2": "^6.24.1",
+    "css-loader": "^0.28.0",
+    "highlight.js": "^9.11.0",
+    "lodash": "^4.17.4",
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4",
+    "react-codemirror": "^0.3.0",
+    "react-markdown-renderer": "^1.2.0",
+    "react-redux": "^5.0.4",
+    "redux": "^3.6.0",
+    "webpack": "^2.3.3"
+  },
+  "devDependencies": {
     "dotenv": "^4.0.0",
     "eslint": "^3.19.0",
     "eslint-loader": "^1.7.1",
@@ -36,9 +38,7 @@
     "eslint-plugin-react": "^6.10.3",
     "eslint-plugin-react-app": "^1.0.2",
     "extract-text-webpack-plugin": "^2.1.0",
-    "react": "^15.5.4",
-    "react-dom": "^15.5.4",
-    "webpack": "^2.3.3",
+    "jest": "^19.0.2",
     "webpack-dev-server": "^2.4.2"
   }
 }

--- a/src/containers/AnnotationDisplay.jsx
+++ b/src/containers/AnnotationDisplay.jsx
@@ -9,6 +9,10 @@ const styles = {
     flex: '1 1 auto',
     maxWidth: '50%',
   },
+  buttonContainer: {
+    display: 'inline-flex',
+    justifyContent: 'flex-start',
+  },
 };
 
 class AnnotationDisplay extends Component {
@@ -28,6 +32,18 @@ class AnnotationDisplay extends Component {
     return (
       <div style={styles.container}>
         <h1>Annotation</h1>
+        <div style={styles.buttonContainer}>
+          <button
+            type="button"
+          >
+            Previous
+          </button>
+          <button
+            type="button"
+          >
+            Next
+          </button>
+        </div>
         <MarkdownRenderer
           markdown={annotation.annotation}
           options={markdownRendererOptions}

--- a/src/containers/AnnotationDisplay.jsx
+++ b/src/containers/AnnotationDisplay.jsx
@@ -106,14 +106,14 @@ class AnnotationDisplay extends Component {
             onClick={this.getPreviousAnnotation}
             type="button"
           >
-            Previous
+            ←
           </button>
           <button
             disabled={hasProceedingAnnotation}
             onClick={this.getNextAnnotation}
             type="button"
           >
-            Next
+            →
           </button>
         </div>
         <div style={styles.markdownContainer}>

--- a/src/containers/AnnotationDisplay.jsx
+++ b/src/containers/AnnotationDisplay.jsx
@@ -2,6 +2,14 @@ import React, { Component, PropTypes } from 'react';
 import MarkdownRenderer from 'react-markdown-renderer';
 import { connect } from 'react-redux';
 
+import { setSelectedLine } from '../actions/app';
+import {
+  getAnnotatedLines,
+  getNextAnnotation,
+  getPreviousAnnotation,
+  hasNextAnnotation,
+  hasPreviousAnnotation,
+} from '../util/annotations';
 import markdownRendererOptions from '../util/markdown-renderer-options';
 
 const styles = {
@@ -16,7 +24,61 @@ const styles = {
 };
 
 class AnnotationDisplay extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      hasPreceedingAnnotation: false,
+      hasProceedingAnnotation: false,
+    };
+    this.getNextAnnotation = this.getNextAnnotation.bind(this);
+    this.getPreviousAnnotation = this.getPreviousAnnotation.bind(this);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const {
+      annotations,
+      selectedLine,
+    } = nextProps;
+    const nextAnnotatedLines = getAnnotatedLines(annotations);
+    this.setState({
+      hasProceedingAnnotation: hasNextAnnotation(nextAnnotatedLines, selectedLine),
+      hasPreceedingAnnotation: hasPreviousAnnotation(nextAnnotatedLines, selectedLine),
+    });
+  }
+
+  getPreviousAnnotation() {
+    const {
+      annotations,
+      dispatch,
+      selectedLine,
+    } = this.props;
+    // Get the annotated lines
+    const previous = getPreviousAnnotation(annotations, selectedLine);
+    if (!previous) {
+      return;
+    }
+    dispatch(setSelectedLine(previous.lineNumber));
+  }
+
+  getNextAnnotation() {
+    const {
+      annotations,
+      dispatch,
+      selectedLine,
+    } = this.props;
+    // Get the annotated lines
+    const next = getNextAnnotation(annotations, selectedLine);
+    if (!next) {
+      return;
+    }
+    dispatch(setSelectedLine(next.lineNumber));
+  }
+
   render() {
+    const {
+      hasPreceedingAnnotation,
+      hasProceedingAnnotation,
+    } = this.state;
     const {
       annotations,
       selectedLine,
@@ -34,11 +96,15 @@ class AnnotationDisplay extends Component {
         <h1>Annotation</h1>
         <div style={styles.buttonContainer}>
           <button
+            disabled={hasPreceedingAnnotation}
+            onClick={this.getPreviousAnnotation}
             type="button"
           >
             Previous
           </button>
           <button
+            disabled={hasProceedingAnnotation}
+            onClick={this.getNextAnnotation}
             type="button"
           >
             Next

--- a/src/containers/AppBody.jsx
+++ b/src/containers/AppBody.jsx
@@ -4,10 +4,11 @@ import axios from 'axios';
 import { setState } from '../actions/app';
 
 import AnnotationDisplay from './AnnotationDisplay';
-import RulesSelector from '../components/RulesSelector';
 import SnippetArea from './SnippetArea';
-import Error from '../components/Error';
 import Title from './Title';
+import Error from '../components/Error';
+import RulesSelector from '../components/RulesSelector';
+import { getFirstAnnotation } from '../util/annotations';
 
 const API_URL = process.env.API_URL;
 const styles = {
@@ -35,11 +36,14 @@ class AppBody extends Component {
     const { dispatch, snippetKey } = this.props;
     const [user, snippet] = snippetKey.split('/');
     axios.get(`${API_URL}/users/${user}/snippets/${snippet}`)
-      .then((res) => {
+      .then(({ data }) => {
         // Some old snippets don't have a snippetLanguage field, so
         // assume they are 'python3'
-        if (!res.data.snippetLanguage) { res.data.snippetLanguage = 'python3'; }
-        dispatch(setState(res.data));
+        if (!data.snippetLanguage) {
+          data.snippetLanguage = 'python3';
+        }
+        data.selectedLine = getFirstAnnotation(data.annotations);
+        dispatch(setState(data));
       })
       .catch(() => {
         this.setState({error: true})

--- a/src/util/annotations.js
+++ b/src/util/annotations.js
@@ -5,3 +5,35 @@ export const getAnnotatedLines = annotations =>
 
 export const getFirstAnnotation = annotations =>
   _.first(getAnnotatedLines(annotations));
+
+export const hasPreviousAnnotation = (annotatedLines, lineNumber) =>
+  _.head(annotatedLines) === lineNumber;
+
+export const hasNextAnnotation = (annotatedLines, lineNumber) =>
+  _.last(annotatedLines) === lineNumber;
+
+export const getPreviousAnnotation = (annotations, displayedLineNumber) => {
+  const annotatedLines = getAnnotatedLines(annotations);
+  if (hasPreviousAnnotation(annotatedLines, displayedLineNumber)) {
+    // First annotation is the one being displayed so there isn't another
+    // annotation before this one; return undefined
+    return undefined;
+  }
+  // Get the index of the currently displayed annotation in the annotatedLines
+  // array and subtract one to get index of the previous annotation
+  const index = _.sortedIndexOf(annotatedLines, displayedLineNumber) - 1;
+  return annotations[annotatedLines[index]];
+};
+
+export const getNextAnnotation = (annotations, displayedLineNumber) => {
+  const annotatedLines = getAnnotatedLines(annotations);
+  if (hasNextAnnotation(annotatedLines, displayedLineNumber)) {
+    // Last annotation is the one being displayed so there isn't another
+    // annotation after this one; return undefined
+    return undefined;
+  }
+  // Get the index of the currently displayed annotation in the annotatedLines
+  // array and add one to get index of the next annotation
+  const index = _.sortedIndexOf(annotatedLines, displayedLineNumber) + 1;
+  return annotations[annotatedLines[index]];
+};

--- a/src/util/annotations.js
+++ b/src/util/annotations.js
@@ -1,0 +1,7 @@
+import _ from 'lodash';
+
+export const getAnnotatedLines = annotations =>
+  _.sortBy(_.keys(annotations).map(key => Number(key)));
+
+export const getFirstAnnotation = annotations =>
+  _.first(getAnnotatedLines(annotations));


### PR DESCRIPTION
Fixes #25 

This PR builds off of #32, adding two buttons to view the next/previous annotations if they exist.

This should be merged after #32 is merged.