### PR TITLE
Open Codesplain links in new tab

### DIFF
--- a/src/components/CodesplainLink.jsx
+++ b/src/components/CodesplainLink.jsx
@@ -1,9 +1,14 @@
 import React from 'react';
 
-const CodesplainLink = ({ snippetKey, style}) => {
+const CodesplainLink = ({ snippetKey, style }) => {
   const properAddress = `https://www.codesplain.io/${snippetKey}`;
   return (
-    <a href={properAddress}><h4 style={style}>{snippetKey}</h4></a>
+    <a
+      href={properAddress}
+      target="_blank" rel="noopener noreferrer"
+    >
+      <h4 style={style}>{snippetKey}</h4>
+    </a>
   );
 }
 


### PR DESCRIPTION
Fixes #40. This PR causes links to Codesplain proper to open in new browser tabs.