### PR TITLE
Use tags array for node type in new snippets

### DIFF
--- a/src/util/highlight.js
+++ b/src/util/highlight.js
@@ -55,17 +55,21 @@ exported wrapper func for this, and starts the recursion.
 */
 export function highlightNode(codeMirror, node, filters, parentColor, rules, ignoredRules) {
   let color = parentColor;
+  // Node's type is the last element of the node's tags property,
+  // if AST was ade with tagging parser. Otherwise, if it was made with
+  // the legacy parser, it is the type property.
+  const type = node.type ? node.type: _.last(node.tags);
 
   // If we aren't ignoring this token...
-  if (ignoredRules.indexOf(node.type) === -1) {
-    const rule = rules[node.type]; // Get the rule obj for this rule
+  if (ignoredRules.indexOf(type) === -1) {
+    const rule = rules[type]; // Get the rule obj for this rule
     // Use this node's color if it has one
     if (rule.color) {
       color = rule.color;
     }
 
     // If this token's filter is not selected
-    if (!filters[node.type] || !filters[node.type].selected) {
+    if (!filters[type] || !filters[type].selected) {
       color = parentColor;
     }
 


### PR DESCRIPTION
Fixes #42.

This PR makes the `highlightNode` function detect whether a snippet's AST was generated by the new or the old parser, and handles the highlighting accordingly. If the AST was generated by the old parser, the node's `type` property is used. If it was generated by the new one, then the last element of its `tags` array is used.